### PR TITLE
Infra: report ingest for javascript reports

### DIFF
--- a/extractor.js
+++ b/extractor.js
@@ -72,11 +72,11 @@ class Extractor {
 
     async compressOutput(){
         this.packagedFile = tmp.fileSync();
-        await compressing.tar.compressDir(this.projectOutputDir.name, this.packagedFile.name)
-            .then(result=>result)
+        await compressing.tar.compressDir(this.projectOutputDir.name, this.packagedFile.name, { ignoreBase: true })
             .catch(function(reason){
                 console.error(reason);
             });
+
         return this.packagedFile.name;
     }
 }

--- a/git.js
+++ b/git.js
@@ -17,7 +17,7 @@ class Git{
                 else { resolve(summary); }
             });
         }.bind(this));
-        const branchResult = await branchPromise.then(result=>result);
+        const branchResult = await branchPromise;
         let info = {};
         if (branchResult.current in branchResult.branches){
             const matches = branchResult.branches[branchResult.current].label.match(/\[(.*)\]/);
@@ -37,7 +37,7 @@ class Git{
             });
         }.bind(this));
 
-        return await revParse.then(result=>result);
+        return await revParse;
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -15,8 +15,8 @@ async function generateReport(configuration){
 
     // lets get the git information for this project folder
     const gitInstance = new git.Git(newConfig.projectDir)
-    let meta = await gitInstance.branchInfo().then(result=>result);
-    meta['commitHash'] = await gitInstance.commitHash().then(result=>result);
+    let meta = await gitInstance.branchInfo();
+    meta['commitHash'] = await gitInstance.commitHash();
 
     var ex = new extractor.Extractor(newConfig.projectDir)
     ex.writeProjectMeta(meta);

--- a/transport.js
+++ b/transport.js
@@ -38,10 +38,9 @@ class Transport {
 
         var form = new FormData();
         form.append('token', token);
-        form.append('reportfile_compressed', fs.createReadStream(filePath));
+        form.append('reportdir_compressed', fs.createReadStream(filePath));
         form.submit(url, function(err, res) {
             if( err ){ console.error(err); }
-            res.resume();
         });
     }
 }


### PR DESCRIPTION
https://softwaresecured.atlassian.net/browse/OM-1186
Infra: report ingest for javascript reports

Description:
removed the 'then' call after the promise, it's not needed
compressed everything but the directory using the ignoreBase
renamed the form label to 'reportdir_compressed'

Test Cases:
validated that extractor still works
validated that upload still works
validated that tar created only contains the files from the root path and not the root path itself