### PR TITLE
Remove local timeout (rely on server)

### DIFF
--- a/__tests__/config.spec.js
+++ b/__tests__/config.spec.js
@@ -45,10 +45,4 @@ describe("Test Configuration", () => {
         var newConfig = new config.Config(invalidConfig);
         expect(newConfig.isValid()).toEqual(true);
     });
-
-    test("it should be an invalid configuration with invalid timeout value", () => {
-        const invalidConfig = { 'token': 'sometoken', 'timeoutSeconds': 'abc' };
-        var newConfig = new config.Config(invalidConfig);
-        expect(newConfig.isValid()).toEqual(false);
-    });
 });

--- a/config.js
+++ b/config.js
@@ -25,7 +25,7 @@ class Config {
         this.token = ('token' in config && config['token']) ? config['token']: null;
         this.projectDir = ('projectDir' in config && config['projectDir']) ? config['projectDir']: '.';
         this.endpoint = ('endpoint' in config && config['endpoint']) ? config['endpoint']: 'https://reshift.reshiftsecurity.com/';
-        this.timeoutSeconds = ('timeoutSeconds' in config && config['timeoutSeconds']) ? config['timeoutSeconds']: detaultTimeoutSeconds;
+        this.timeoutSeconds = detaultTimeoutSeconds;
         this.language = ('language' in config && config['language']) ? config['language']: null;
     }
 
@@ -45,10 +45,6 @@ class Config {
         });
         parser.addArgument( [ '-e', '--endpoint' ], { 
             help: 'Optional host endpoint, default https://reshift.reshiftsecurity.com/',
-            required: false
-        });
-        parser.addArgument( [ '-s', '--timeoutSeconds' ], { 
-            help: 'Optional timeout in seconds, default ' + detaultTimeoutSeconds.toString(),
             required: false
         });
         parser.addArgument( [ '-l', '--language' ], { 
@@ -71,11 +67,6 @@ class Config {
         }
         if ( !this.endpoint || !validUrl.isUri(this.endpoint) ){
             console.error('Configuration Error: invalid endpoint; endpoint URL needs to be a valid http(s) url');
-            return false;
-        }
-        this.timeoutSeconds = Number.parseInt(this.timeoutSeconds);
-        if ( !this.timeoutSeconds || !Number.isInteger(this.timeoutSeconds) ){
-            console.error('Configuration Error: invalid timeoutSeconds value');
             return false;
         }
 

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ async function runScan(configuration) {
     const meta = await gitInstance.branchInfo();
     meta.commitHash = await gitInstance.commitHash();
     var branch = meta.remotes
-    if (!!!branch) {
+    if (!branch) {
        branch = meta.local
        console.warn('WARN: Unable to get project git state. Project is either in a detached state or our of sync with remote.');
     }

--- a/main.js
+++ b/main.js
@@ -19,12 +19,12 @@ async function runScan(configuration) {
     const repoInfo = await gitInstance.getRepositoryInfo();
     const meta = await gitInstance.branchInfo();
     meta.commitHash = await gitInstance.commitHash();
-    var branch = meta.remotes
+    var gitStatus = await gitInstance.getGitStatus();
+    var branch = gitStatus.tracking
     if (!branch) {
        branch = meta.local
-       console.warn('WARN: Unable to get project git state. Project is either in a detached state or our of sync with remote.');
+       console.warn('WARN: Unable to get project git state. Project is either in a detached state or out of sync with remote.');
     }
-    var gitStatus = await gitInstance.getGitStatus();
     if (!gitStatus.isClean()) {
         console.warn('WARN: Git project seems to have local changes or is not clean. Local changes will not be scanned.');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshiftsecurity/reshift-plugin-npm",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reshiftsecurity/reshift-plugin-npm",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Security vulnerability scanner",
     "license": "MIT",
     "repository": "https://github.com/softwaresecured/npm_plugin",

--- a/scan-service.js
+++ b/scan-service.js
@@ -115,7 +115,7 @@ class ScanService {
         const executionTime = this.serviceRequestIntervalMS * attemptCounter;
         if (executionTime > this.serviceTimeoutMS) {
             if (overtimeNotice) {
-                this.log('Scan execution time is taking a little longer than expected...');
+                this.log('Scan is still running. Execution time is taking a little longer than expected...');
                 // Display notice only once
                 overtimeNotice = false;
             }


### PR DESCRIPTION
Removing timeouts from plugin (relying on scan process to timeout).
SUGGESTION: Adding an overtime notice based on default time setting to let the user know it is still running. We could alternatively show some sort of progress spinner.