### PR TITLE
Adding --nonblocking flag

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,6 +14,7 @@ class Config {
         this.projectDir = null;
         this.endpoint = null;
         this.logLevel = null;
+        this.nonblocking = null;
 
         if(!config){
             // The caller did not pass in a configuration dictionary
@@ -30,6 +31,7 @@ class Config {
         this.endpoint = ('endpoint' in config && config['endpoint']) ? config['endpoint']: 'https://reshift.reshiftsecurity.com/';
         this.timeoutSeconds = detaultTimeoutSeconds;
         this.logLevel = ('logLevel' in config && config['logLevel']) ? config['logLevel']: 'info';
+        this.nonblocking = 'nonblocking' in config && config['nonblocking'] ? config['nonblocking'] > 0: false;
     }
 
     parseCLI(){
@@ -52,6 +54,11 @@ class Config {
         });
         parser.addArgument( [ '-l', '--logLevel' ], { 
             help: util.format('Optional plugin logging level (default: info). Options are: %s', logger.validLogLevels),
+            required: false
+        });
+        parser.addArgument( [ '-n', '--nonblocking' ], {
+            type: 'int',
+            help: 'Optional non-blocking scan. Will return immediately once scan is initialized.',
             required: false
         });
 

--- a/main.js
+++ b/main.js
@@ -62,7 +62,8 @@ async function runScan(configuration) {
         configuration.token,
         projectProviderUrl,
         branch,
-        meta.commitHash
+        meta.commitHash,
+        configuration.nonblocking
     );
     var scanTimeMs = new Date() - start;
     log.info(util.format("Finished in %s", prettyMilliseconds(scanTimeMs)));

--- a/scan-service.js
+++ b/scan-service.js
@@ -150,7 +150,7 @@ class ScanService {
         return false
     }
 
-    async executeScan(token, projectProviderUrl, branch, commitHash) {
+    async executeScan(token, projectProviderUrl, branch, commitHash, nonblocking) {
         assert(token, 'invalid token');
         assert(branch, 'invalid request body');
         assert(commitHash, 'invalid commit hash');
@@ -175,6 +175,11 @@ class ScanService {
         this.log.debug('Sending scan request');
         const scanResponse = await this.sendRequest(scanRequestOptions);
         if(scanResponse.statusUrl) {
+            if (!!nonblocking)
+            {
+                this.log.info('Scan initialized, login to Reshift for report details.');
+                return true;
+            }
             this.log.info('Scan initialized, executing...')
             return await this.getScanStatus(scanResponse.statusUrl, token, scanResponse.scanStatus);
         } else {


### PR DESCRIPTION
This is a proposal to add a "nonblocking" flag to the Reshift CLI.

The idea is to allow scans to be initialized by the CLI without blocking on the finished scan results. Use cases for this may be projects where scans take too long to block the CI on specific branches or when a scan is initiated for the purposes of the dashboard and notifications, but the results are not required inline.

If a user specifies `-n 1` or `--nonblocking 1` the CLI will exit 0 immediately after initializing a scan (if the scan initializes successfully) and the user will receive a message indicating that they should see the Reshift dashboard for report details.

NOTES:
- `argparse` does not appear have a boolean type or a parameter-less flag option without an action so i'm using an `int` type where >0=true.
- Wasn't sure about returning `reportUrl` to the user immediately or not. Is that guaranteed to be available for the pending scan or will it return the previous scan results for the same branch? I just left it as a message indicating they should check the dashboard as some other responses do.
- Not sure about the name `--nonblocking`. Maybe `--async`, `--noresponse` or something else?
- I didn't update the docs or tests as it didn't seem relevant given the scope.
- The CLI will not block on thresholds in nonblocking mode, all non-error exits will be code 0
- Also considered it might be useful to return the scan id from the scan url and another option to take in a scan id and return the current status of that instead of initiating a scan.
- Another alternate concept might be a `timeout` or `tries` option that limits the amount of scan status checks and a value <=0 would cause it to exit immediately.